### PR TITLE
add MaxServers setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 60
         env:
+        # Maximum number of servers to return in response, # default is 0 and it means unlimited
+        - name: JAWLB_MAXSERVERS
+          value: "5"
         # The name of the upstream service we want
         # to balance
         - name: JAWLB_SERVICE

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ var cfg = struct {
 	Service       string `desc:"Name of the service in Kubernetes" required:"true"`
 	LabelSelector string `desc:"Label selector for the service (foo=bar,baz=bang)"`
 	TargetPort    string `default:"grpc" desc:"Target port name to forward to"`
+	MaxServers    int    `default:"0" desc:"Maximum number of servers to return in response, 0 means unlimited"`
 
 	WatchMaxRetries int           `default:"60" desc:"Number of times to retry establishing the Kubernetess watch"`
 	WatchRetryDelay time.Duration `default:"1s" desc:"Delay between retries"`
@@ -94,7 +95,7 @@ func startServer(bc *broadcast) *grpc.Server {
 	}
 
 	srv := grpc.NewServer()
-	grpclb.RegisterLoadBalancerServer(srv, &lb{bc, 0})
+	grpclb.RegisterLoadBalancerServer(srv, &lb{bc, cfg.MaxServers})
 
 	go func() {
 		if err := srv.Serve(conn); err != nil {


### PR DESCRIPTION
With this setting, we can limit the number of servers return to each client, so we can avoid this situation where every single server instance establishes a connection to every single client which requires a huge amount of memory in cases where there are lots of clients.